### PR TITLE
feat: RAG（類似症例検索）の実装とベクトル生成パイプラインの構築

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,9 @@ TZ=Asia/Tokyo
 
 # セッション管理等のためのシークレットキー（適当な乱数に変更してください）
 SECRET_KEY=change_this_to_a_random_secret_string
+
+# ==========================================
+# Embedding Settings
+# ==========================================
+# エンベディングモデルのプロバイダー (ruri または gemini)
+EMBEDDING_PROVIDER=ruri

--- a/backend/app/adapters/embedding/base.py
+++ b/backend/app/adapters/embedding/base.py
@@ -1,0 +1,15 @@
+"""
+File: backend/app/adapters/embedding/base.py
+"""
+from abc import ABC, abstractmethod
+from typing import List
+
+class BaseEmbeddingClient(ABC):
+    """エンベディングクライアントの抽象ベースクラス"""
+    
+    @abstractmethod
+    def embed_text(self, text: str) -> List[float]:
+        """
+        テキストを受け取り、ベクトル（List[float]）を返す
+        """
+        pass

--- a/backend/app/adapters/embedding/factory.py
+++ b/backend/app/adapters/embedding/factory.py
@@ -1,0 +1,24 @@
+"""
+File: backend/app/adapters/embedding/factory.py
+"""
+import os
+import logging
+from app.adapters.embedding.base import BaseEmbeddingClient
+
+logger = logging.getLogger(__name__)
+
+def get_embedding_client() -> BaseEmbeddingClient:
+    """
+    環境変数 EMBEDDING_PROVIDER に基づいて、適切なエンベディングクライアントを返す。
+    デフォルトは 'ruri'。
+    """
+    provider = os.getenv("EMBEDDING_PROVIDER", "ruri").lower()
+    
+    if provider == "gemini":
+        logger.info("Using Gemini Embedding Client")
+        from app.adapters.embedding.gemini_embedding_client import GeminiEmbeddingClient
+        return GeminiEmbeddingClient()
+    else:
+        logger.info("Using Local Ruri Embedding Client")
+        from app.adapters.embedding.ruri_client import RuriEmbeddingClient
+        return RuriEmbeddingClient()

--- a/backend/app/adapters/embedding/gemini_embedding_client.py
+++ b/backend/app/adapters/embedding/gemini_embedding_client.py
@@ -1,0 +1,61 @@
+"""
+File: backend/app/adapters/embedding/gemini_embedding_client.py
+"""
+import os
+import math
+import logging
+from typing import List
+
+from google import genai
+from google.genai import types
+
+from app.adapters.embedding.base import BaseEmbeddingClient
+
+logger = logging.getLogger(__name__)
+
+class GeminiEmbeddingClient(BaseEmbeddingClient):
+    """
+    Google Gemini (gemini-embedding-2-preview) を使用したベクトル生成クライアント。
+    ruri-v3と互換性を持たせるため、出力次元数を768次元に設定します。
+    """
+    def __init__(self):
+        logger.info("Initializing GeminiEmbeddingClient with gemini-embedding-2-preview")
+        api_key = os.getenv("GEMINI_API_KEY")
+        if not api_key:
+            logger.warning("[GeminiEmbeddingClient] Warning: GEMINI_API_KEY is not set.")
+        
+        self.client = genai.Client(api_key=api_key)
+        self.model_name = "gemini-embedding-2-preview"
+
+    def embed_text(self, text: str) -> List[float]:
+        try:
+            # gemini-embedding-2-preview の推奨フォーマット
+            # 患者同士の類似度検索（Symmetric format）に最適化するため、タスクプレフィックスを追加します。
+            formatted_text = f"task: sentence similarity | query: {text}"
+
+            # 次元数を768に切り詰めて生成
+            result = self.client.models.embed_content(
+                model=self.model_name,
+                contents=formatted_text,
+                config=types.EmbedContentConfig(
+                    output_dimensionality=768
+                )
+            )
+            
+            # APIから返却されたベクトルを取得
+            values = result.embeddings[0].values
+
+            # 【重要】768次元など小さい次元に切り詰めた場合、手動でのL2正規化(Normalization)が推奨されています
+            # 外部ライブラリ(numpy)に依存しない標準のmathモジュールで計算します
+            magnitude = math.sqrt(sum(v * v for v in values))
+            
+            if magnitude > 0:
+                normed_embedding = [v / magnitude for v in values]
+            else:
+                normed_embedding = values
+                
+            return normed_embedding
+
+        except Exception as e:
+            logger.error(f"Error during Gemini vector generation: {e}", exc_info=True)
+            raise

--- a/backend/app/adapters/embedding/ruri_client.py
+++ b/backend/app/adapters/embedding/ruri_client.py
@@ -1,0 +1,23 @@
+import logging
+from sentence_transformers import SentenceTransformer
+from typing import List
+from app.adapters.embedding.base import BaseEmbeddingClient
+
+logger = logging.getLogger(__name__)
+
+class RuriEmbeddingClient(BaseEmbeddingClient):
+    def __init__(self, model_name: str = "cl-nagoya/ruri-v3-310m"):
+        logger.info(f"Initializing RuriEmbeddingClient with model: {model_name}")
+        try:
+            self.model = SentenceTransformer(model_name)
+        except Exception as e:
+            logger.error(f"Failed to load embedding model {model_name}: {e}")
+            raise
+
+    def embed_text(self, text: str) -> List[float]:
+        try:
+            vector = self.model.encode(text, normalize_embeddings=True).tolist()
+            return vector
+        except Exception as e:
+            logger.error(f"Error during Ruri vector generation: {e}")
+            raise

--- a/backend/app/infrastructure/repositories/patient_repository.py
+++ b/backend/app/infrastructure/repositories/patient_repository.py
@@ -8,12 +8,15 @@ Summary:
 Tags: Repository, Database, Patients, Hybrid Search, pgvector, CRUD
 """
 
+import json
 from sqlalchemy import select, and_, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List, Optional
 
 from app.infrastructure.db.models import PatientsView, DocumentsView
 from app.schemas.schemas import PatientCreate
+from app.adapters.embedding.factory import get_embedding_client
+from app.usecases.utils.context_builder import prepare_patient_facts
 
 class PatientRepository:
     """
@@ -27,6 +30,24 @@ class PatientRepository:
         患者を新規登録します。
         """
         print(f"[PatientRepository] Creating patient with hash_id: {patient.hash_id}")
+
+        # ベクトル(social_vector)の自動生成処理
+        vector_data = patient.social_vector
+        if not vector_data:
+            try:
+                print(f"[PatientRepository] Start generating embedding vector for {patient.hash_id}")
+                # Pydanticモデルからフラットな辞書を作成し、事実情報を構築
+                flat_data = patient.model_dump()
+                facts_dict = prepare_patient_facts(flat_data)
+                searchable_text = json.dumps(facts_dict, ensure_ascii=False)
+                
+                # Factoryを使って環境変数に応じたクライアントを取得し、ベクトルを生成
+                embedding_client = get_embedding_client()
+                vector_data = embedding_client.embed_text(searchable_text)
+                print(f"[PatientRepository] Successfully generated social_vector (dimension: {len(vector_data) if vector_data else 0})")
+            except Exception as e:
+                print(f"[PatientRepository] Vectorization failed for {patient.hash_id}: {e}")
+                vector_data = None
         
         # モデルインスタンスの作成
         db_patient = PatientsView(
@@ -40,7 +61,7 @@ class PatientRepository:
             outcome=patient.outcome,
             total_fim_admission=patient.total_fim_admission,
             mental_min=patient.mental_min,
-            social_vector=patient.social_vector
+            social_vector=vector_data
         )
         
         # DBに追加してコミット

--- a/backend/app/schemas/extraction_schemas.py
+++ b/backend/app/schemas/extraction_schemas.py
@@ -10,7 +10,7 @@ Tags: Schema, Pydantic, Data Extraction, ADL, Mapping, Conversion
 
 from datetime import date
 from typing import Optional, Literal, Dict, Any
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 # ==========================================
 # 1. Basic & Header Information
@@ -44,6 +44,17 @@ class BasicInfoSchema(BaseModel):
     treatment_details: Optional[str] = Field(None, description="治療内容")
     onset_date: Optional[date] = Field(None, description="発症日または手術日")
     rehab_start_date: Optional[date] = Field(None, description="リハビリテーション開始日")
+
+    @field_validator('evaluation_date', 'onset_date', 'rehab_start_date', mode='before')
+    @classmethod
+    def parse_frontend_date(cls, v):
+        """フロントエンド固有のオブジェクト形式から日付文字列を抽出する"""
+        if isinstance(v, dict):
+            raw_date = v.get('raw') or v.get('full')
+            if raw_date:
+                # "2026/04/12" のような形式を "2026-04-12" に変換
+                return str(raw_date).replace('/', '-')
+        return v
 
     # Therapy Types
     therapy_pt: Optional[bool] = Field(None, description="理学療法(PT)の実施有無")
@@ -521,6 +532,15 @@ class SignatureSchema(BaseModel):
     explained_to: Optional[str] = Field(None)
     explanation_date: Optional[date] = Field(None)
     explainer: Optional[str] = Field(None)
+
+    @field_validator('explanation_date', mode='before')
+    @classmethod
+    def parse_frontend_date(cls, v):
+        if isinstance(v, dict):
+            raw_date = v.get('raw') or v.get('full')
+            if raw_date:
+                return str(raw_date).replace('/', '-')
+        return v
 
 
 # ==========================================

--- a/backend/app/usecases/plan_generation.py
+++ b/backend/app/usecases/plan_generation.py
@@ -23,8 +23,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import create_model, Field
 
 from app.adapters.llm.factory import get_llm_client
+from app.adapters.embedding.factory import get_embedding_client
 from app.core.constants import PATIENT_FIELD_LABELS
 from app.infrastructure.repositories.plan_repository import PlanRepository
+from app.infrastructure.repositories.rag_repository import RAGRepository
 from app.schemas.extraction_schemas import PatientExtractionSchema
 from app.schemas.legacy_schemas import GENERATION_GROUPS
 from app.schemas.schemas import PlanCreate
@@ -206,6 +208,51 @@ class PlanGenerationUseCase:
         facts_str = json.dumps(facts, ensure_ascii=False, indent=2)
         
         logger.debug(f"execute_custom: Formatted facts length: {len(facts_str)} chars")
+
+        # =========================================================================
+        # [RAG / 類似症例検索]
+        # その場でベクトルを生成し、過去の類似事例を検索してプロンプトに組み込む
+        # =========================================================================
+        similar_cases_str = ""
+        try:
+            logger.info("execute_custom: Generating vector for RAG similarity search...")
+            # 検索用テキストの作成（DB保存時と同じ形式に）
+            searchable_text = json.dumps(facts, ensure_ascii=False)
+            
+            # リアルタイムでベクトル生成 (Ruri または Gemini)
+            embedding_client = get_embedding_client()
+            target_vector = embedding_client.embed_text(searchable_text)
+            
+            # 類似症例の検索
+            rag_repo = RAGRepository(self.db)
+            
+            # 同一疾患の患者に絞るためのフィルタ
+            filters = {}
+            if "diagnosis_code" in flat_data and flat_data["diagnosis_code"]:
+                 filters["diagnosis"] = str(flat_data["diagnosis_code"])
+            
+            # 自身(現在編集中の患者)の除外用ID（取得できれば）
+            current_hash_id = validated_data.basic.name if validated_data.basic else None
+                 
+            # ベクトル検索の実行
+            similar_docs = await rag_repo.search_similar_documents(
+                query_vector=target_vector,
+                filters=filters,
+                exclude_hash_id=current_hash_id,
+                limit=2
+            )
+            
+            if similar_docs:
+                similar_docs_json = json.dumps(similar_docs, ensure_ascii=False, indent=2)
+                similar_cases_str = f"\n【参考情報 (過去の類似事例)】\n以下の過去事例を参考に、今回の患者様に適した内容を生成してください。\n```json\n{similar_docs_json}\n```\n"
+                logger.info(f"execute_custom: Found {len(similar_docs)} similar cases.")
+            else:
+                logger.info("execute_custom: No similar cases found.")
+                
+        except Exception as e:
+            logger.error(f"execute_custom: Error during RAG similarity search: {e}", exc_info=True)
+            # 検索に失敗しても生成自体は続行する
+        # =========================================================================
         
         # 既存計画のコンテキスト化
         plan_context_str = ""
@@ -220,12 +267,13 @@ class PlanGenerationUseCase:
 【患者データ】
 {facts_str}
 {plan_context_str}
+{similar_cases_str}
 【指示】
 {prompt}
 
 出力は指示された内容のみをテキストで返してください。余計な挨拶は不要です。
 """
-        logger.info(f"Executing Custom Generation Prompt: {prompt[:50]}...")
+        logger.info(f"Executing Custom Generation Prompt with RAG: {prompt[:50]}...")
         
         # テキスト生成としてLLMを呼び出し
         response_text = await self.llm_client.generate_text(full_prompt)

--- a/backend/app/usecases/utils/prompts.py
+++ b/backend/app/usecases/utils/prompts.py
@@ -31,15 +31,22 @@ def build_group_prompt(
     group_schema: Type[BaseModel],
     patient_facts_str: str,
     generated_plan_so_far: Dict[str, Any],
+    similar_cases_str: str = ""
 ) -> str:
     """
     計画書生成（グループ単位）用のプロンプトを構築する
     """
+    # RAGコンテキスト（類似症例）がある場合のみヘッダーを付ける
+    rag_text = ""
+    if similar_cases_str:
+        rag_text = f"# 参考情報 (類似過去事例)\n過去の類似症例データです。専門的な表現や計画の方向性を参考にしつつ、今回の患者様に適した形に調整して活用してください。\n```json\n{similar_cases_str}\n```\n"
+
     # テンプレートに渡す変数を辞書として準備
     variables = {
         "patient_facts": patient_facts_str,
         "generated_plan": json.dumps(generated_plan_so_far, indent=2, ensure_ascii=False, default=str),
         "fim_guidelines": FIM_GUIDELINES,
+        "similar_cases_context": rag_text,
         "schema_json": json.dumps(group_schema.model_json_schema(), indent=2, ensure_ascii=False)
     }
 

--- a/backend/app/usecases/utils/templates/plan_generation.txt
+++ b/backend/app/usecases/utils/templates/plan_generation.txt
@@ -15,6 +15,7 @@ ${patient_facts}
 
   ```json
 ${generated_plan}
+${similar_cases_context}
   ```
 
 # 重要な参照基準

--- a/backend/requirements/local_gpu.txt
+++ b/backend/requirements/local_gpu.txt
@@ -1,1 +1,2 @@
 ollama
+sentence-transformers

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -29,6 +29,7 @@ services:
       LOG_LEVEL: debug
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       LLM_PROVIDER: ${LLM_PROVIDER}
+      EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER}
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
ベテランの臨床推論を再現するため、過去の類似カルテを参照して計画書を生成するRAGシステムを実装しました。また、ローカル/クラウド環境に応じたエンベディングモデルの切り替え機能や、結合テストで発覚したバリデーションエラーの修正を行っています。

[Backend: エンベディング・RAG機能]
* アダプター層 (adapters/embedding/): Factoryパターンを用い、環境変数に応じてローカル(ruri-v3)とクラウド(Gemini)のエンベディングクライアントを切り替える機能を新規実装。
* データアクセス層 (patient_repository.py): 患者新規登録（Seeder投入含む）時に、コンテキスト化したテキスト情報から自動でベクトルを生成し、DB(pgvector)へ保存する処理を追加。
* ユースケース層 (plan_generation.py): 全体生成(execute)および部分生成(execute_custom)の実行時、患者データからリアルタイムでベクトルを生成し、RAG検索による類似過去事例を取得するロジックを追加。
* プロンプト定義 (prompts.py, plan_generation.txt): 取得した類似過去事例のデータを、動的にLLMへのプロンプトテキスト内へ展開するよう修正。

[Backend: バグ修正]
* extraction_schemas.py: フロントエンドのカレンダーUI等から送信される独自形式の日付オブジェクト（{raw: ...}）によるPydanticのバリデーションエラー(500)を解消するため、文字列へ変換するカスタムバリデーター(@field_validator)を追加。

[Infra / Ops]
* compose.override.yaml: 開発環境のバックエンドコンテナにエンベディングモデル切り替え用の EMBEDDING_PROVIDER 環境変数が渡るように設定を追加。
* requirements/local_gpu.txt: ローカルでのベクトル生成に必須となる sentence-transformers パッケージを追加。