### PR TITLE
feat: AI生成の根拠となる類似症例（RAGエビデンス）のUI表示機能を追加

### DIFF
--- a/backend/app/api/v1/endpoints/plans.py
+++ b/backend/app/api/v1/endpoints/plans.py
@@ -108,17 +108,17 @@ async def generate_custom_part(
 ):
     """
     カスタムプロンプトに基づいて部分的なテキスト生成を行います。
-    結果はJSONで {"result": "生成されたテキスト"} として返します。
+    結果はJSONで {"result": "生成されたテキスト", "references": [...]} として返します。
     """
-    print(f"[API] POST /plans/generate/custom Request received.")
+    print("[API] POST /plans/generate/custom Request received.")
     
     usecase = PlanGenerationUseCase(db)
     try:
-        result_text = await usecase.execute_custom(
+        response_data = await usecase.execute_custom(
             patient_data=request.patient_data,
             prompt=request.prompt
         )
-        return {"result": result_text}
+        return response_data
     except Exception as e:
         print(f"[API] Error during custom generation: {e}")
         raise HTTPException(

--- a/backend/app/usecases/plan_generation.py
+++ b/backend/app/usecases/plan_generation.py
@@ -24,7 +24,7 @@ from pydantic import create_model, Field
 
 from app.adapters.llm.factory import get_llm_client
 from app.adapters.embedding.factory import get_embedding_client
-from app.core.constants import PATIENT_FIELD_LABELS
+# from app.core.constants import PATIENT_FIELD_LABELS
 from app.infrastructure.repositories.plan_repository import PlanRepository
 from app.infrastructure.repositories.rag_repository import RAGRepository
 from app.schemas.extraction_schemas import PatientExtractionSchema
@@ -187,7 +187,7 @@ class PlanGenerationUseCase:
         patient_data: Dict[str, Any],
         prompt: str,
         current_plan: Optional[Dict[str, Any]] = None
-    ) -> str:
+    ) -> Dict[str, Any]:
         """
         カスタムプロンプトによる部分生成を実行します。
         
@@ -214,6 +214,7 @@ class PlanGenerationUseCase:
         # その場でベクトルを生成し、過去の類似事例を検索してプロンプトに組み込む
         # =========================================================================
         similar_cases_str = ""
+        references_list = []
         try:
             logger.info("execute_custom: Generating vector for RAG similarity search...")
             # 検索用テキストの作成（DB保存時と同じ形式に）
@@ -243,6 +244,30 @@ class PlanGenerationUseCase:
             )
             
             if similar_docs:
+                # フロントエンドの型に合わせてデータを抽出
+                for doc in similar_docs:
+                    doc_dict = doc if isinstance(doc, dict) else (getattr(doc, "__dict__", {}))
+                    
+                    # entitiesが辞書型 {"diagnosis": ["脳梗塞"]} の場合、フラットなリストに変換
+                    raw_entities = doc_dict.get("entities", [])
+                    formatted_entities = []
+                    if isinstance(raw_entities, dict):
+                        for k, v in raw_entities.items():
+                            if isinstance(v, list):
+                                formatted_entities.extend(v)
+                            else:
+                                formatted_entities.append(str(v))
+                    elif isinstance(raw_entities, list):
+                        formatted_entities = raw_entities
+                        
+                    references_list.append({
+                        "id": doc_dict.get("hash_id") or doc_dict.get("doc_id", "不明"),
+                        "title": doc_dict.get("doc_type", "過去事例"),
+                        "similarity": doc_dict.get("similarity", 0.9), 
+                        "content": doc_dict.get("summary_text") or doc_dict.get("original_text", ""),
+                        "entities": formatted_entities
+                    })
+
                 similar_docs_json = json.dumps(similar_docs, ensure_ascii=False, indent=2)
                 similar_cases_str = f"\n【参考情報 (過去の類似事例)】\n以下の過去事例を参考に、今回の患者様に適した内容を生成してください。\n```json\n{similar_docs_json}\n```\n"
                 logger.info(f"execute_custom: Found {len(similar_docs)} similar cases.")
@@ -278,7 +303,10 @@ class PlanGenerationUseCase:
         # テキスト生成としてLLMを呼び出し
         response_text = await self.llm_client.generate_text(full_prompt)
         
-        return response_text
+        return {
+            "result": response_text,
+            "references": references_list
+        }
 
     async def execute_batch(
         self,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -72,7 +72,7 @@ export const ApiClient = {
     prompt: string, 
     targetKey?: string,
     currentPlan?: Record<string, any>
-  ): Promise<{ result: string }> => {
+  ): Promise<{ result: string; references?: any[] }> => {
     const response = await fetch(`${API_BASE_URL}/plans/generate/custom`, {
       method: 'POST',
       headers: {

--- a/frontend/src/features/dashboard/LeftPanel.tsx
+++ b/frontend/src/features/dashboard/LeftPanel.tsx
@@ -11,7 +11,7 @@
 import React, { useEffect, useState } from 'react';
 import { usePlanContext } from './PlanContext';
 import { ApiClient } from '../../api/client';
-import { ChevronDown, ChevronRight, LayoutGrid, Save, Plus, Trash2, ArrowRight, MousePointerClick } from 'lucide-react';
+import { ChevronDown, ChevronRight, LayoutGrid, Save, Plus, Trash2, ArrowRight, MousePointerClick, BookOpen } from 'lucide-react';
 import { ValueMapping } from '../../api/types';
 
 const presetBtnStyle: React.CSSProperties = {
@@ -129,6 +129,58 @@ const getValue = (obj: any, path: string) => {
   return path.split('.').reduce((acc, part) => acc && acc[part], obj);
 };
 
+// ユーティリティ: RAGの生テキスト（Python辞書文字列等）を見やすく整形する
+const formatReference = (ref: any) => {
+  // contentとentitiesの両方にデータが分散している可能性があるため結合
+  const allText = [ref.content, ...(ref.entities || [])].join('\n');
+
+  const extractStr = (key: string) => {
+    const match = allText.match(new RegExp(`'${key}'\\s*:\\s*'([^']+)'`));
+    return match ? match[1] : null;
+  };
+  const extractNum = (key: string) => {
+    const match = allText.match(new RegExp(`'${key}'\\s*:\\s*([0-9]+)`));
+    return match ? match[1] : null;
+  };
+
+  const disease = extractStr('disease_name');
+  const age = extractStr('age_display') || extractNum('age');
+  const gender = extractStr('gender');
+  const risks = extractStr('risks');
+  const comorbidities = extractStr('comorbidities');
+  const stg = extractStr('short_term_goal');
+  const ltg = extractStr('long_term_goal');
+
+  // 長すぎる辞書データを除外し、本当のタグ（短い文字列）だけを残す
+  const realTags = (ref.entities || []).filter((e: any) => typeof e === 'string' && e.length < 30);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      {(disease || risks || stg || ltg) ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', fontSize: '0.75rem', color: '#475569' }}>
+          {disease && <div><span style={{fontWeight: 'bold', color: '#334155'}}>疾患:</span> {disease} {age ? `(${age}${gender ? `・${gender}` : ''})` : ''}</div>}
+          {comorbidities && <div><span style={{fontWeight: 'bold', color: '#334155'}}>合併症:</span> {comorbidities}</div>}
+          {risks && <div><span style={{fontWeight: 'bold', color: '#334155'}}>リスク:</span> {risks}</div>}
+          {stg && <div><span style={{fontWeight: 'bold', color: '#334155'}}>短期目標:</span> {stg}</div>}
+          {ltg && <div><span style={{fontWeight: 'bold', color: '#334155'}}>長期目標:</span> {ltg}</div>}
+        </div>
+      ) : (
+        ref.content ? <p style={{ fontSize: '0.75rem', color: '#475569', margin: 0, lineHeight: 1.5, display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>{ref.content}</p> : null
+      )}
+      
+      {realTags.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+          {realTags.map((e: string) => (
+            <span key={e} style={{ fontSize: '0.65rem', backgroundColor: 'white', color: '#64748b', padding: '2px 6px', border: '1px solid #e2e8f0', borderRadius: '4px' }}>
+              #{e}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
 // ==============================================================
 // 2. Components
 // ==============================================================
@@ -138,7 +190,8 @@ const LeftPanel: React.FC = () => {
     patientData, setPatientData, registerPatientName, 
     currentHashId, setCurrentHashId, patientList,
     fieldConfigs, updateFieldConfig, saveStructureToStorage,
-    selectedCellAddress
+    selectedCellAddress,
+    references
   } = usePlanContext();
   
   const [isLoading, setIsLoading] = useState(false);
@@ -449,6 +502,35 @@ const LeftPanel: React.FC = () => {
              患者を選択すると詳細が表示されます。
            </div>
         )}
+
+        {/* RAG 参照エビデンス表示エリア */}
+        <div style={{ padding: '16px', borderTop: '4px solid #f1f5f9', background: 'white' }}>
+          <h3 style={{ fontSize: '0.95rem', fontWeight: 'bold', color: '#334155', display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '12px' }}>
+            <BookOpen size={16} color="#4f46e5" /> 参照エビデンス (RAG)
+          </h3>
+          
+          {(!references || references.length === 0) ? (
+            <p style={{ fontSize: '0.8rem', color: '#94a3b8', fontStyle: 'italic', margin: 0 }}>
+              生成時に使用された根拠がここに表示されます
+            </p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              {references.map((ref) => (
+                <div key={ref.id} style={{ padding: '12px', backgroundColor: '#eff6ff', border: '1px solid #bfdbfe', borderRadius: '8px' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
+                    <span style={{ fontSize: '0.8rem', fontWeight: 'bold', color: '#1d4ed8' }}>類似症例: {ref.id}</span>
+                    <span style={{ fontSize: '0.7rem', backgroundColor: '#bfdbfe', color: '#1e40af', padding: '2px 6px', borderRadius: '4px', fontWeight: 500 }}>
+                      適合度: {Math.round(ref.similarity * 100)}%
+                    </span>
+                  </div>
+                  
+                  {formatReference(ref)}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
       </div>
     </div>
   );

--- a/frontend/src/features/dashboard/PlanContext.tsx
+++ b/frontend/src/features/dashboard/PlanContext.tsx
@@ -72,7 +72,19 @@ const STORAGE_KEY_PLAN_STRUCTURE = 'rehab_app_plan_structure';
 const STORAGE_KEY_NAME_MAP = 'rehab_app_patient_name_map';
 const STORAGE_KEY_FIELD_CONFIG = 'rehab_app_field_config_v1';
 
+export interface ReferenceSource {
+  id: string;
+  title: string;
+  similarity: number;
+  content: string;
+  entities?: string[];
+}
+
 interface PlanContextType {
+  // 参照ソース (RAG)
+  references: ReferenceSource[];
+  setReferences: (refs: ReferenceSource[]) => void;
+
   // 生成結果の計画書
   currentPlan: PlanRead | null;
   setCurrentPlan: (plan: PlanRead) => void;
@@ -115,6 +127,7 @@ interface PlanContextType {
 const PlanContext = createContext<PlanContextType | undefined>(undefined);
 
 export const PlanProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [references, setReferences] = useState<ReferenceSource[]>([]);
   const [currentPlan, setCurrentPlan] = useState<PlanRead | null>(null);
   const [patientData, setPatientData] = useState<PatientExtractionData | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -254,6 +267,7 @@ const getPatientName = useCallback((hashId: string): string | null => {
 
   return (
     <PlanContext.Provider value={{ 
+      references, setReferences,
       currentPlan, setCurrentPlan, 
       patientData, setPatientData,
       isGenerating, setIsGenerating,

--- a/frontend/src/features/dashboard/RightPanel.tsx
+++ b/frontend/src/features/dashboard/RightPanel.tsx
@@ -255,7 +255,8 @@ const RightPanel: React.FC = () => {
     planStructure, setPlanStructure, 
     resetPlanStructure, saveStructureToStorage,
     getPatientName,
-    selectedCellAddress
+    selectedCellAddress,
+    setReferences
   } = usePlanContext();
   
   // 同時生成のためにSetでIDを管理
@@ -337,13 +338,18 @@ const RightPanel: React.FC = () => {
       const planId = currentPlanRef.current?.plan_id;
 
       // 生成API呼び出し
-      const { result } = await ApiClient.generateCustom(
+      const { result, references } = await ApiClient.generateCustom(
         patientData, 
         item.prompt, 
         item.targetKey,
         contextRawData 
       );
       
+      // 参照ソースをContextに保存して左ペインに表示
+      if (references) {
+        setReferences(references);
+      }
+
       // 保存処理
       const latestRawData = currentPlanRef.current?.raw_data || {};
       const newRawData = { ...latestRawData, [item.targetKey]: result };


### PR DESCRIPTION
AIによる計画書提案の透明性と療法士の納得感を高めるため、RAGが検索した過去の類似症例やカルテ文脈をフロントエンド（左ペイン）で確認できる機能を追加しました。

[Backend]
* usecases/plan_generation.py: execute_customにて、ベクトル検索で取得したsimilar_docsを抽出し、生成テキストと共に
eferencesリストとして返却するよう修正
* api/v1/endpoints/plans.py: カスタム生成APIのレスポンスを修正し、生成結果(result)とエビデンス(references)を包含した辞書を返すようエンドポイントを調整

[Frontend]
* src/features/dashboard/PlanContext.tsx: 参照ソースをグローバル状態として管理するため、ReferenceSource型の定義と
eferencesステートを追加
* src/features/dashboard/RightPanel.tsx: 生成ボタン押下時(handleGenerate)に、APIレスポンスから
eferencesを受け取りContextに保存する処理を追加
* src/features/dashboard/LeftPanel.tsx: パネル下部に「参照エビデンス (RAG)」セクションを新設。バックエンドから渡されるPython辞書形式の生文字列から「疾患・年齢・リスク・目標」などを抽出し、療法士が読みやすいカードデザインに変換するヘルパー関数（ormatReference）を実装
* src/api/client.ts: generateCustomの戻り値の型定義に
eferencesを追加して型安全性を向上